### PR TITLE
[fix] A bug in the example section

### DIFF
--- a/man/strata.Rd
+++ b/man/strata.Rd
@@ -38,7 +38,7 @@ but for the labeling of the factors (\code{strata} is more verbose).
 \code{\link{coxph}}, \code{\link{interaction}}
 }
 \examples{
-a <- factor(rep(1:3,4), labels="low", "medium", "high")
+a <- factor(rep(1:3,4), labels=c("low", "medium", "high"))
 b <- factor(rep(1:4,3))
 levels(strata(b))
 levels(strata(a,b,shortlabel=TRUE))


### PR DESCRIPTION
First line of examples wasn't working due to lack of c() and it was throwing a warning and returning NAs