### PR TITLE
R_forceSymbols() requires R >= 3.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Title: Survival Analysis
 Maintainer: Terry M Therneau <therneau.terry@mayo.edu>
 Priority: recommended
 Package: survival
-Version: 2.41-3
+Version: 2.41-4
 Depends: R (>= 2.13.0)
 Imports: graphics, Matrix, methods, splines, stats, utils
 LazyData: Yes

--- a/src/init.c
+++ b/src/init.c
@@ -6,6 +6,7 @@
 */
 #include "survS.h"
 #include "R_ext/Rdynload.h"
+#include <Rversion.h>
 #include "survproto.h"
 
 static const R_CMethodDef Centries[] = {
@@ -66,6 +67,8 @@ void R_init_survival(DllInfo *dll){
     ** This line makes them only be available via the symbols above
     **  i.e., .Call("tmerge", ) won't work but .Call(Ctmerge, )  will
     */
+#if defined(R_VERSION) && R_VERSION >= R_Version(3, 0, 0)
     R_forceSymbols(dll, TRUE);
+#endif
 }
     


### PR DESCRIPTION
The package won't install on R < 3.0.0. This change, analogous to https://github.com/gagolews/stringi/commit/4322d4bf1cf59c8adfa4b87c967fa170c53dbc92, should fix the problem. Tested with R 2.15.2.