### PR TITLE
Update tmerge.Rnw

### DIFF
--- a/noweb/tmerge.Rnw
+++ b/noweb/tmerge.Rnw
@@ -536,7 +536,7 @@ else {
         storage.mode(dstop) <- storage.mode(etime) <- "double"
         new <- .Call(Ctmerge, match(baseid, baseid), dstop, as.numeric(newvar), 
                     match(id, baseid)[keep], etime[keep], 
-                    as.numeric(yinc[keep]), indx[keep])
+                    as.numeric(y2[keep]), indx[keep])
 
         if (is.factor(yinc)) newvar <- factor(new, labels=newlev)
         else newvar <- newlev[new]


### PR DESCRIPTION
fix call to Ctmerge for tdc() on a character covariate. #52 