### PR TITLE
Fix integer overflow issue with large datasets

### DIFF
--- a/R/residuals.coxph.S
+++ b/R/residuals.coxph.S
@@ -13,7 +13,7 @@ residuals.coxph <-
 	}
     if (type=='scaledsch') type<-'schoenfeld'
 
-    n <- length(object$residuals)
+    n <- as.double(length(object$residuals))
     rr <- object$residuals
     y <- object$y
     x <- object[['x']]  # avoid matching object$xlevels


### PR DESCRIPTION
Prevents errors for cases where the number of observations is less than 2^31-1, but the product of the number of rows and columns exceeds that limit.  Addresses #54 