### PR TITLE
Devtools install

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,11 +3,7 @@ noweb/.*.log
 noweb/.*.tex
 noweb/.*.out
 noweb/.*.pdf
-noweb/casecohort.Rnw
-noweb/concordance.old.Rnw
 noweb/figures
-noweb/predict.coxph.Rnw
-noweb/ratetable.Rnw
 src/Readme
 src/surv_callback.csp
 src/cox_callback.csp
@@ -24,7 +20,6 @@ vignettes/.*.log
 vignettes/.*.tex
 vignettes/.*.pdf
 vignettes/old
-noweb/noweb.sty
 fail
 Readme.md
 R/plot.survexp.R.notdone

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Version: 3.1-1
 Date: 2019-09-08
 Depends: R (>= 3.4.0)
 Imports: graphics, Matrix, methods, splines, stats, utils
+Suggests: noweb
 LazyData: Yes
 LazyLoad: Yes
 ByteCompile: Yes
@@ -20,5 +21,3 @@ Description: Contains the core survival analysis routines, including
 	     and parametric accelerated failure time models.
 License: LGPL (>=2)
 URL: https://github.com/therneau/survival
-
-

--- a/noweb/Makefile
+++ b/noweb/Makefile
@@ -90,25 +90,25 @@ test: $(RFUN)
 
 %.R: 
 	echo "# Automatically generated from the noweb directory" > $@
-	echo "require(noweb); notangle('code.nw', target='$(*F)', out='zz')" | R  --slave
-	cat zz >> $@
-	rm zz
+	echo "require(noweb); notangle('code.nw', target='$(*F)', out='z$(@F)')" | R  --slave
+	cat z$(@F) >> $@
+	rm z$(@F)
 
 %.S: 
 	echo "# Automatically generated from the noweb directory" > $@
-	echo "require(noweb); notangle('code.nw', target='$(*F)', out='zz')" | R  --slave
-	cat zz >> $@
-	rm zz
+	echo "require(noweb); notangle('code.nw', target='$(*F)', out='z$(@F)')" | R  --slave
+	cat z$(@F) >> $@
+	rm z$(@F)
 
 %.c: 
 	echo "/* Automatically generated from the noweb directory */" > $@
-	echo "require(noweb); notangle('code.nw', target='$(*F)', out='zz')" | R  --slave
-	cat zz >> $@
-	rm zz
+	echo "require(noweb); notangle('code.nw', target='$(*F)', out='z$(@F)')" | R  --slave
+	cat z$(@F) >> $@
+	rm z$(@F)
 
 clean:
-	-rm code.nw code.log code.aux code.toc code.tex code.bbl code.blg code.out
-	-rm noweb.sty
+	-rm -f code.nw code.log code.aux code.toc code.tex code.bbl code.blg code.out
+	-rm -f noweb.sty
 
 noweb.sty:
 	echo 'library(noweb); data(noweb); cat(noweb.sty, sep="\n", file="noweb.sty")' |  R  --slave


### PR DESCRIPTION
Some small changes to make `devtools::install_github()` and other devtools functions work "out of the box". This also as a byproduct makes `R CMD INSTALL` and friends work with the development repo. Because `noweb` is only added to Suggests you do have to specify `devtools::install_github("therneau/survival", dependencies = TRUE)` in order to install if the `noweb` package is not already installed on the system.

I also modified the makefile to work with parallel make, it would fail otherwise.

Fixes https://www.mail-archive.com/r-devel@r-project.org/msg41078.html