### PR TITLE
Update adjucurve vignette section 5.1 indexing in loop

### DIFF
--- a/vignettes/adjcurve.Rnw
+++ b/vignettes/adjcurve.Rnw
@@ -780,7 +780,7 @@ for (i in 1:3) {
     for (j in 1:16) {
         stemp <- summary(temp[j], times=xtime, extend=T)
         smat[,i] <- smat[,i] + pi[j]*stemp$surv
-        serr[,i] <- serr[,i] + pi[i]*stemp$std.err^2
+        serr[,i] <- serr[,i] + pi[j]*stemp$std.err^2
         }
     }
 serr <- sqrt(serr)


### PR DESCRIPTION
Thanks for the very helpful vignette.  I've been using it to build adjusted curves with matrices of different dimensions than the example.  From trouble shooting that, I believe the indexing was wrong in the vignette, and needed to be `j` rather than `i`.