### PR TITLE
ridge function to preserve factor levels

### DIFF
--- a/R/ridge.R
+++ b/R/ridge.R
@@ -1,10 +1,13 @@
 # $Id: ridge.S 11166 2008-11-24 22:10:34Z therneau $
 ridge <- function(..., theta, df=nvar/2, eps=.1, scale=TRUE) {
-    x <- cbind(...)
-    nvar <- ncol(x)
-    xname <- as.character(parse(text=substitute(cbind(...))))[-1]
-    vars <- apply(x, 2, function(z) var(z[!is.na(z)]))
-    class(x) <- 'coxph.penalty'
+  
+  xvars        <- cbind(data.frame( list(...) ))
+  names(xvars) <- as.character(parse(text=substitute(cbind(...))))[-1]
+  x            <- model.matrix(~.,model.frame(~., data=xvars, na.action=na.pass))[,-1]
+  nvar         <- ncol(x)
+  xname        <- colnames(x)
+  vars         <- apply(x, 2, function(z) var(z[!is.na(z)]))
+  class(x)     <- 'coxph.penalty'
 
     if (!missing(theta) && !missing(df))
 	    stop("Only one of df or theta can be specified")


### PR DESCRIPTION
Hi Terry,

Thank you for the survival package. 

For consideration, I've updated the ridge function so that it maintains factor levels.  This entailed using the model.matrix function on ridge covariates as compared to cbinding the covariates.  Penalization is calculated as before.

The scripts and output below compare the difference when using the original vs updated ridge function.

[originalRidgeOut.txt](https://github.com/therneau/survival/files/4927174/originalRidgeOut.txt)
[originalRidgeScript.txt](https://github.com/therneau/survival/files/4927175/originalRidgeScript.txt)
[updateRidgeOut.txt](https://github.com/therneau/survival/files/4927185/updateRidgeOut.txt)
[updateRidgeScript.txt](https://github.com/therneau/survival/files/4927186/updateRidgeScript.txt)

Kind regards,

Jonathan Chipman