### PR TITLE
fixed bug in summary.coxph when wald.test is NULL

### DIFF
--- a/R/summary.coxph.R
+++ b/R/summary.coxph.R
@@ -28,7 +28,7 @@ summary.coxph <- function(object,  conf.int = 0.95, scale = 1, ...) {
                                "se(coef)", "robust se", "z", "Pr(>|z|)"))
         }
     rval$coefficients <- tmp
-     
+
     if (conf.int) {
         z <- qnorm((1 + conf.int)/2, 0, 1)
         tmp <- cbind(exp(beta), exp(-beta), exp(beta - z * se),
@@ -49,10 +49,12 @@ summary.coxph <- function(object,  conf.int = 0.95, scale = 1, ...) {
                      pvalue= pchisq(cox$score, df, lower.tail=FALSE))
     rval$rsq<-c(rsq=1-exp(-logtest/cox$n),
                  maxrsq=1-exp(2*cox$loglik[1]/cox$n))
-    rval$waldtest<-c(test=as.vector(round(cox$wald.test, 2)),
-                      df=df,
-                      pvalue= pchisq(as.vector(cox$wald.test), df, 
-                                     lower.tail=FALSE))
+    if (!is.null(cox$wald.test)) {
+        rval$waldtest<-c(test=as.vector(round(cox$wald.test, 2)),
+                         df=df,
+                         pvalue=pchisq(as.vector(cox$wald.test), df,
+                                       lower.tail=FALSE))
+    }
     if (!is.null(cox$rscore))
          rval$robscore<-c(test=cox$rscore,
                           df=df,


### PR DESCRIPTION
In r, `round(NULL)` will produce error:

`Error in round(NULL) : non-numeric argument to mathematical function`

Hence:

```r
    rval$waldtest<-c(test=as.vector(round(cox$wald.test, 2)),
                      df=df,
                      pvalue= pchisq(as.vector(cox$wald.test), df, 
                                     lower.tail=FALSE))
```

will produce error when `cox$wald.test` is `NULL`.

Apparently, the constructor  function for a `coxph` object does allow for `cox$wald.test` to be `NULL`.

I assume that when `cox$wald.test` is `NULL`, then `rval$waldtest` should be `NULL` as well.