### PR TITLE
avoid partial matching when running survreg

### DIFF
--- a/R/print.survreg.R
+++ b/R/print.survreg.R
@@ -8,7 +8,7 @@ print.survreg <- function(x, ...)
 	cat(" Survreg failed.", x$fail, "\n")
 	return(invisible(x))
 	}
-    coef <- x$coef
+    coef <- x$coefficients
     if(any(nas <- is.na(coef))) {
 	if(is.null(names(coef))) names(coef) <- paste("b", 1:length(coef), sep = "")
         cat("\nCoefficients: (", sum(nas), 
@@ -26,7 +26,7 @@ print.survreg <- function(x, ...)
 	}
 
     pdig <- max(1, getOption("digits")-4)  # default it too high IMO
-    nobs <- length(x$linear)
+    nobs <- length(x$linear.predictors)
     chi <- 2*diff(x$loglik)
     df  <- sum(x$df) - x$idf   # The sum is for penalized models
     cat("\nLoglik(model)=", format(round(x$loglik[2],1)),

--- a/R/survreg.R
+++ b/R/survreg.R
@@ -282,7 +282,7 @@ survreg <- function(formula, data, weights, subset, na.action,
 
     # set singular coefficients to NA
     #  this is purposely not done until the residuals, etc. are computed
-    singular <- (diag(fit$var)==0)[1:length(fit$coef)]
+    singular <- (diag(fit$var)==0)[1:length(fit$coefficients)]
     if (any(singular)) fit$coef <- ifelse(singular, NA, fit$coef)
 
     na.action <- attr(m, "na.action")


### PR DESCRIPTION
Thanks for the package! Here are some places where perhaps partial matching can be avoided in `survreg`.