### PR TITLE
Patch fix for long formula names

### DIFF
--- a/R/coxph.R
+++ b/R/coxph.R
@@ -33,7 +33,10 @@ coxph <- function(formula, data, weights, subset, na.action,
                  terms(formula[[1]], specials=ss, data=data)
     else Terms <- if (missing(data)) terms(formula, specials=ss) else
                  terms(formula, specials=ss, data=data)
-
+    attr(Terms,'term.labels') = gsub('\n',' ', attr(Terms,'term.labels'))
+    colnames(attr(Terms,'factors')) = gsub('\n',' ', colnames(attr(Terms,'factors')))
+    rownames(attr(Terms,'factors')) = gsub('\n',' ', rownames(attr(Terms,'factors')))
+    
     tcl <- attr(Terms, 'specials')$cluster
     if (length(tcl) > 1) stop("a formula cannot have multiple cluster terms")
 
@@ -127,7 +130,10 @@ coxph <- function(formula, data, weights, subset, na.action,
     # okay, now evaluate the formula
     mf <- eval(tform, parent.frame())
     Terms <- terms(mf)
-
+    attr(Terms,'term.labels') = gsub('\n',' ', attr(Terms,'term.labels'))
+    colnames(attr(Terms,'factors')) = gsub('\n',' ', colnames(attr(Terms,'factors')))
+    rownames(attr(Terms,'factors')) = gsub('\n',' ', rownames(attr(Terms,'factors')))
+    
     # Grab the response variable, and deal with Surv2 objects
     n <- nrow(mf)
     Y <- model.response(mf)


### PR DESCRIPTION
Patching a bug caused by an issue with the terms function in the stats package. 

For very long feature names, such as those introduced by using the [ridge](https://github.com/cran/survival/blob/master/R/ridge.R) function with many parameters the terms function splits the variable names by inserting a new line character. 

Heres a demo example: 
`terms(as.formula(paste0('~ridge(',paste0('variable',1:50,collapse = ','),',theta = 1,scale = TRUE)')))`
returns an object where attr(,"term.labels") and attr(,"factors") names have been split by a new line character '\n' (for me this was around variable 42).

The reason this is a problem is because later on in the coxph function (lines 541 and 543 [here](https://github.com/cran/survival/blob/master/R/coxph.R)) it tries to match a version of the string with the newline character (attr(Terms, 'term.labels') and names(assign)) and one without (pname). It fails and returns NA. This in turn falsely triggers the error on line 542.