### PR TITLE
Fix figure reference in competing risk vignette

### DIFF
--- a/vignettes/compete.Rnw
+++ b/vignettes/compete.Rnw
@@ -721,7 +721,7 @@ values $P$ can be complex, even if the models for the hazards are relatively
 simple. 
 The primary idea of the Fine-Gray approach is to turn the multi-state 
 problem into a collection of two-state ones. 
-In the upper right diagram of figure 1, draw a circle around all of the
+In the upper right diagram of figure 2, draw a circle around all of the
 states except the chosen endpoint and collapse them into a single meta-state.
 For the MGUS data these are 
 \begin{itemize}


### PR DESCRIPTION
The upper right diagram of figure 1 is a depiction of generic sequential events. I believe this line is supposed to refer to the upper right diagram of figure 2, which is a depiction of a multi-state model for the MGUS data.