### PR TITLE
Allow for error in `survival:::terms.inner()`

### DIFF
--- a/R/xtras.R
+++ b/R/xtras.R
@@ -46,7 +46,7 @@ rep.Surv <- function(x, ...) {
 
 # This function is just like all.vars -- except that it does not recur
 #  on the $ sign, it follows both arguments of +, *, - and : in order to
-#  track formulas, all arguments of Surv, and only the first of things
+#  track formulas, all arguments of Surv, and only the first of things 
 #  like ns().  And - it works only on formulas.
 # This is used to generate a warning in coxph if the same variable is used
 #  on both sides, so perfection is not required of the function.
@@ -56,7 +56,7 @@ terms.inner <- function(x) {
         if (length(x) ==3) c(terms.inner(x[[2]]), terms.inner(x[[3]]))
         else terms.inner(x[[2]])
     }
-    else if (inherits(x, "call") &&
+    else if (inherits(x, "call") && 
              (x[[1]] != as.name("$") && x[[1]] != as.name("["))) {
         if (x[[1]] == '+' || x[[1]]== '*' || x[[1]] == '-' || x[[1]] ==':') {
             # terms in a model equation, unary minus only has one argument
@@ -72,7 +72,7 @@ terms.inner <- function(x) {
   error = function(e) return(character(0L))
   )
 }
-
+   
 # If a subject had (start, stop) observations of (1,2) (2,10) (10,15) (20,25),
 #  say, code often wants to distiguish intervals that are "real" censoring
 #  from a simple split due to a time dependent covariate.
@@ -83,7 +83,7 @@ survflag <- function(y, id) {
     if (!inherits(y, "Surv")) stop("y must be a Surv object")
     if (nrow(y) != length(id)) stop("length mismatch")
     if (ncol(y) != 3) stop("y needs to be of (tstart, tstop) form")
-
+  
     n <- nrow(y)
     indx <- order(id, y[,2])  # sort the data by time within id
     y2 <- y[indx,]
@@ -91,7 +91,7 @@ survflag <- function(y, id) {
 
     newid <- (id2[-n] != id2[-1])
     gap <-  (y2[-n,2] < y2[-1,1]) 
-
+   
     flag <- 1L*c(TRUE, newid | gap) + 2L*c(newid | gap, TRUE)
     flag[indx] <- flag   # return it to data order
     flag

--- a/R/xtras.R
+++ b/R/xtras.R
@@ -46,16 +46,17 @@ rep.Surv <- function(x, ...) {
 
 # This function is just like all.vars -- except that it does not recur
 #  on the $ sign, it follows both arguments of +, *, - and : in order to
-#  track formulas, all arguments of Surv, and only the first of things 
+#  track formulas, all arguments of Surv, and only the first of things
 #  like ns().  And - it works only on formulas.
 # This is used to generate a warning in coxph if the same variable is used
 #  on both sides, so perfection is not required of the function.
 terms.inner <- function(x) {
+  tryCatch({
     if (inherits(x, "formula")) {
         if (length(x) ==3) c(terms.inner(x[[2]]), terms.inner(x[[3]]))
         else terms.inner(x[[2]])
     }
-    else if (inherits(x, "call") && 
+    else if (inherits(x, "call") &&
              (x[[1]] != as.name("$") && x[[1]] != as.name("["))) {
         if (x[[1]] == '+' || x[[1]]== '*' || x[[1]] == '-' || x[[1]] ==':') {
             # terms in a model equation, unary minus only has one argument
@@ -67,8 +68,11 @@ terms.inner <- function(x) {
         else terms.inner(x[[2]])
     }
     else(deparse(x))
+  },
+  error = function(e) return(character(0L))
+  )
 }
-   
+
 # If a subject had (start, stop) observations of (1,2) (2,10) (10,15) (20,25),
 #  say, code often wants to distiguish intervals that are "real" censoring
 #  from a simple split due to a time dependent covariate.
@@ -79,7 +83,7 @@ survflag <- function(y, id) {
     if (!inherits(y, "Surv")) stop("y must be a Surv object")
     if (nrow(y) != length(id)) stop("length mismatch")
     if (ncol(y) != 3) stop("y needs to be of (tstart, tstop) form")
-  
+
     n <- nrow(y)
     indx <- order(id, y[,2])  # sort the data by time within id
     y2 <- y[indx,]
@@ -87,7 +91,7 @@ survflag <- function(y, id) {
 
     newid <- (id2[-n] != id2[-1])
     gap <-  (y2[-n,2] < y2[-1,1]) 
-   
+
     flag <- 1L*c(TRUE, newid | gap) + 2L*c(newid | gap, TRUE)
     flag[indx] <- flag   # return it to data order
     flag


### PR DESCRIPTION
Hello! I am working with incredibly structured CDISC data. All CDISC data use the same column names to define the outcomes of survival data: the time to outcome variable is `AVAL` and the binary indicator of censoring (the opposite of how `Surv()` would code it) is called `CNSR`.

I was hoping to write a wrapper for `Surv()` that takes advantage of these strict naming conventions to ease use for the many in pharma who use CDISC data. I called my function `Surv_CDSIC()`, but ran into an issue when `terms.inner()` was parsing the LHS of the formula and the arguments in `Surv_CDSIC()`. As there are no arguments in `Surv_CDISC()`, there is a script out of bounds error when `terms.inner()` seeks to parse them.

The comments directly above the definition of the `terms.inner()` function say, "This [function] is used to generate a warning in coxph if the same variable is used on both sides, so perfection is not required of the function." Since perfection is not required and this is used to only warn users about a potential syntax issue, I am hoping you're amenable to a small update to account for this situation.

In this pull request, I merely added ` tryCatch()` around the subscripting code. If there is an error parsing the argument (because in this case there are _no_ arguments), rather than returning an error the function returns an empty character vector (which is what `all.vars()` returns when there are no variables in a formula).

Thank you for your time and consideration for this pull request! This is related to issue #199 posted by @dmurdoch .


If it helps, here's the current implementation of the function I am working on:

``` r
# devtools::install_github("openpharma/visR") # install visR for the CDISC dataset

Surv_CDISC <- function(AVAL, CNSR) {
  # set default values if not passed by user -----------------------------------
  if (missing(AVAL) && exists("AVAL", envir = rlang::caller_env()))
    AVAL <- get("AVAL", envir = rlang::caller_env())
  else if (missing(AVAL))
    stop("Default 'AVAL' value not found. Specify argument in `Surv_CDISC(AVAL=)`.")
  if (missing(CNSR) && exists("CNSR", envir = rlang::caller_env()))
    CNSR <- get("CNSR", envir = rlang::caller_env())
  else if (missing(CNSR))
    stop("Default 'CNSR' value not found. Specify argument in `Surv_CDISC(CNSR=)`.")
  
  # pass args to `survival::Surv()` --------------------------------------------
  survival::Surv(time = AVAL, event = 1 - CNSR)
}

survival::coxph(Surv_CDISC() ~ SEX, data = visR::adtte)
#> Call:
#> survival::coxph(formula = Surv_CDISC() ~ SEX, data = visR::adtte)
#> 
#>        coef exp(coef) se(coef)     z     p
#> SEXM 0.3147    1.3699   0.1626 1.935 0.053
#> 
#> Likelihood ratio test=3.71  on 1 df, p=0.05412
#> n= 254, number of events= 152
```

<sup>Created on 2022-06-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
