### PR TITLE
add  p.value in `survdiff`

### DIFF
--- a/R/print.survdiff.R
+++ b/R/print.survdiff.R
@@ -39,7 +39,7 @@ print.survdiff <- function(x, digits = max(options()$digits - 4, 3), ...) {
 				  "(O-E)^2/E", "(O-E)^2/V"))
 	print(temp)
 	cat("\n Chisq=", format(round(x$chisq,1)),
-		 " on", df, "degrees of freedom, p=",
+		 " on", df, "degrees of freedom, p.value=",
 		 format.pval(pchisq(x$chisq, df, lower.tail=FALSE)),
             "\n")
        }

--- a/R/survdiff.R
+++ b/R/survdiff.R
@@ -79,9 +79,9 @@ survdiff <- function(formula, data, subset, na.action, rho=0, timefix=TRUE) {
 	    vv <- (fit$var[df,df])[-1,-1, drop=FALSE]
 	    chi <- sum(solve(vv, temp2) * temp2)
 	    }
-
+	df <- (sum(1*(etmp>0))) -1
 	rval <-list(n= table(groups), obs = fit$observed,
-		    exp = fit$expected, var=fit$var,  chisq=chi)
+		    exp = fit$expected, var=fit$var,  chisq=chi, p.value= round(pchisq(chi, df, lower.tail=FALSE), 3))
 	if (length(strats)) rval$strata <- table(strata.keep)
 	}
 


### PR DESCRIPTION
I added the `p.value` inside the list as commenting on https://github.com/therneau/survival/issues/198 and changed in cat `p` to `p.value` for consistency
```r
df = leukemia
test = survdiff(Surv(df$time, df$status)~df$x, rho=0)
```
```r
> test$p.value
[1] 0.065
```

```r
> test 
Call:
survdiff(formula = Surv(df$time, df$status) ~ df$x, 
    rho = 0)

                    N Observed Expected (O-E)^2/E (O-E)^2/V
df$x=Maintained    11        7    10.69      1.27       3.4
df$x=Nonmaintained 12       11     7.31      1.86       3.4

 Chisq= 3.4  on 1 degrees of freedom, p.value= 0.07
```