### PR TITLE
Resizing hex sticker in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# survival
-![Survival package for R](man/figures/logo.png)
- 
+# survival <img src='man/figures/logo.png' align="right" height="120" />
+
 This is the source code for the "survival" package in R.  It gets posted to the
 comprehensive R archive (CRAN) at intervals, each such posting preceded a
 throrough test. (I run the test suite for all 800+ packages that depend on


### PR DESCRIPTION
Just a itty bitty change to re-size the hex logo in the README.md file. Currently no size is set, the the image takes up the entire width of the screen.

![image](https://user-images.githubusercontent.com/26774684/173389294-6b080430-16f7-4d2f-8300-a780c8901263.png)

With this small update, the hex sticker appears on the right and is smaller.

![image](https://user-images.githubusercontent.com/26774684/173389462-19824212-2fee-40bf-b560-43a8888dcd24.png)
