### PR TITLE
Minor change: avoid partial matching

### DIFF
--- a/R/survfitKM.R
+++ b/R/survfitKM.R
@@ -211,9 +211,9 @@ survfitKM <- function(x, y, weights=rep(1.0,length(x)),
                      n.event= cfit$n[,5],
                      n.censor=cfit$n[,6],
                      surv = cfit$estimate[,1],
-                     std.err = cfit$std[,1],
+                     std.err = cfit$std.err[,1],
                      cumhaz  = cfit$estimate[,2],
-                     std.chaz = cfit$std[,2])
+                     std.chaz = cfit$std.err[,2])
      } else {
          strata <- sapply(cfit, function(x) if (is.null(x$n)) 0L else nrow(x$n))
          names(strata) <- xlev
@@ -224,9 +224,9 @@ survfitKM <- function(x, y, weights=rep(1.0,length(x)),
                       n.event= unlist(lapply(cfit, function(x) x$n[,5])),
                       n.censor=unlist(lapply(cfit, function(x) x$n[,6])),
                       surv =   unlist(lapply(cfit, function(x) x$estimate[,1])),
-                      std.err =unlist(lapply(cfit, function(x) x$std[,1])),
+                      std.err =unlist(lapply(cfit, function(x) x$std.err[,1])),
                       cumhaz  =unlist(lapply(cfit, function(x) x$estimate[,2])),
-                      std.chaz=unlist(lapply(cfit, function(x) x$std[,2])),
+                      std.chaz=unlist(lapply(cfit, function(x) x$std.err[,2])),
                       strata=strata)
           if (ny==3) rval$n.enter <- unlist(lapply(cfit, function(x) x$n[,8]))
     }


### PR DESCRIPTION
The result of `.Call(Csurvfitkm)` returns a `std.err` member which is referred to using partial matching, i.e. `cfit$std`.

When using environements where partial matching is strongly discouraged, this triggers warnings, even in packages that only import `survival`.

For instance, these options are sometimes enforced and running `survfit()` with these on will trigger warnings:
```r
options(
  warnPartialMatchArgs=TRUE,
  warnPartialMatchAttr=TRUE,
  warnPartialMatchDollar=TRUE, #this one
)
```
