### PR TITLE
Use inplace decrement operator

### DIFF
--- a/src/fastkm.c
+++ b/src/fastkm.c
@@ -169,7 +169,7 @@ SEXP fastkm2(SEXP y2, SEXP wt2, SEXP sort12, SEXP sort22) {
 	    nevent++;
 	    for (; k<n; k++) {
 		p1 = sort1[k];
-		if (tstart[p1] >= dtime) ntemp =- wt[p1];
+		if (tstart[p1] >= dtime) ntemp -= wt[p1];
 		else break;
 	    }
 	}


### PR DESCRIPTION
As flagged by our compiler.

I don't know the code well, so I am not 100% sure this is correct, but glancing around I see `+=` / `-=` used for these `*temp` objects, so I think it is (the alternative is `ntemp = -wt[p1];`, which is what the current code is doing, but with clearer spacing).