### PR TITLE
fix a bug and return individual score function under the null

### DIFF
--- a/R/coxph.fit.R
+++ b/R/coxph.fit.R
@@ -69,6 +69,15 @@ coxph.fit <- function(x, y, strata, offset, init, control,
                      as.double(control$toler.chol),
                      as.vector(init),
                      ifelse(zero.one, 0L, 1L))
+    
+    if(!is.null(coxfit$null_score)){
+      coxfit$null_score <- matrix(coxfit$null_score, ncol = ncol(x), byrow = FALSE)
+      rownames(coxfit$null_score) <- rownames(x)[sorted]
+      coxfit$null_score <- coxfit$null_score[rownames(x), , drop = FALSE]
+      coxfit$null_imat <- matrix(coxfit$null_imat, ncol = ncol(x), byrow = FALSE)
+      coxfit$logrank <- solve(coxfit$null_imat, colSums(coxfit$null_score))
+      coxfit$logrank_vcov <- nrow(coxfit$null_score) * solve(coxfit$null_imat) %*% cov(coxfit$null_score) %*% solve(coxfit$null_imat)
+    }
 
     if (nullmodel) {
         if (resid) {
@@ -130,6 +139,10 @@ coxph.fit <- function(x, y, strata, offset, init, control,
 		    iter   = coxfit$iter,
 		    linear.predictors = as.vector(lp),
 		    means = coxfit$means,
+		    null_score = coxfit$null_score,
+		    null_imat = coxfit$null_imat,
+		    logrank = coxfit$logrank,
+		    logrank_vcov = coxfit$logrank_vcov,
                     method = method,
  		    class ='coxph')
 	if (resid) {


### PR DESCRIPTION
1. imat should be a symmetric matrix. Latest version is not.

2. logrank test is equivalent to the score test of cox ph model. inv(null_imat) %*% null_score can be used to compute the covariance between logrank test and other test statistics (e.g. log hazard ratio, or estimates of other models based on the same data). I hope this individual level score under the null can be returned by coxph as  well.

More context about 2).

Many estimates can be approximated as inv(hessian) %*% (sum of individual scores). The logrank test is the score test based on the Cox PH model under the null. If individual score under the null is available, we can define one-sided logrank test based on S = inv(null hessian) %*% (sum of null individual score), and the testing statistic is S' %*% inv(null hessian) %*% cov(null score) %*% inv(null hessian) %*% S (two sided) or S^2 * diag(inv(null hessian) %*% cov(null score) %*% inv(null hessian)) (one-sided). 

Imagining that another model (M1) is also fitted on the same data. The estimates can be approximated as inv(hessian) %*% (sum of individual scores). With the null score of the Cox PH model, we can compute the covariance between estimates of M1 and the one-sided logrank statistic. 
