### PR TITLE
Prevent negative indexing in tmerge().

### DIFF
--- a/src/tmerge.c
+++ b/src/tmerge.c
@@ -119,7 +119,7 @@ SEXP tmerge2(SEXP id2,  SEXP time1x, SEXP nid2, SEXP ntime2) {
 	for (; k< n2 && (nid[k] == id[i]) && (ntime[k] <= time1[i]); k++) {
 	    index[i] = k+1;
 	}
-	k--;  /* the next obs might need the same k */
+	if (k > 0) k--;  /* the next obs might need the same k */
     }
 
     UNPROTECT(1);


### PR DESCRIPTION
Fixing a bug where 'nid2' integer vector was accessed with k=-1. By pure luck nid[-1] currently gives 0, instead of garbage value. (I'm recreating the pull request, beacuse I polluted the previous one).

Additional info:
`k=-1` case is triggered for example in `multi2.R` test when evaluating `tdata`
```
tdata <- tmerge(myeloid[,1:3], myeloid, id=id, death=event(futime,death),
                priortx = tdc(txtime), sct= event(txtime))
```

After applying `if (k > 0)` fix all survival tests passed successfully.