### PR TITLE
Support `survdiff()` on a `survfit` object

### DIFF
--- a/R/survdiff.R
+++ b/R/survdiff.R
@@ -3,6 +3,12 @@ survdiff <- function(formula, data, subset, na.action, rho=0, timefix=TRUE) {
     m <- match.call(expand.dots=FALSE)
     m$rho <- NULL
 
+    if (inherits(formula, "survfit")) {
+      fit <- formula
+      formula <- as.formula(fit$call$formula, env=parent.frame())
+      data <- get(fit$call$data, envir=parent.frame())
+      m$data <- data
+    }
     if (!inherits(formula, 'formula'))
         stop("The 'formula' argument is not a formula")
     # make Surv(), strata() etc in a formula resolve to the survival namespace

--- a/tests/cancer.R
+++ b/tests/cancer.R
@@ -11,6 +11,9 @@ temp <- survfit(Surv(time, status) ~ ph.ecog, lung)
 summary(temp, times=c(30*1:11, 365*1:3))
 print(temp[2:3])
 
+temp <- survdiff(temp, rho=.5) #survdiff on a survfit object
+print(temp, digits=6)
+
 temp <- survfit(Surv(time, status)~1, lung, type='fleming',
 		   conf.int=.9, conf.type='log-log', error='tsiatis')
 summary(temp, times=30 *1:5)


### PR DESCRIPTION
Dear Pr Therneau,

In my analyses, I almost never calculate a `survdiff` test without plotting the KM curves.
This results in the formula being written twice in my code, which is tedious and error-prone in case I want to modify it.

Here is a small improvement suggestion where you can use the `survfit` object directly instead:

``` r
library(survival)

survdiff(Surv(time, status) ~ inst, data=lung, rho=.5)$pvalue
#> [1] 0.5903835

km <- survfit(Surv(time, status) ~ inst, lung)
survdiff(km, rho=.5)$pvalue
#> [1] 0.5903835
```

<sup>Created on 2025-07-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Many thanks once more for your work on this exceptionally useful package.

Best regards
Dan
