### PR TITLE
update required R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Priority: recommended
 Package: survival
 Version: 3.8-8
 Date: 2026-05-17
-Depends: R (>= 3.5.0)
+Depends: R (>= 4.1.0)
 Imports: graphics, Matrix, methods, splines, stats, utils
 LazyData: Yes
 LazyDataCompression: xz


### PR DESCRIPTION
Some functions in 'survival' now use `deparse1` (from R 4.0.0) or ` ...names` (from R 4.1.0), which means some examples and vignettes fail in older R versions. This patch updates the R version requirement in the `DESCRIPTION` file accordingly.