### PR TITLE
fix Rd sectioning

### DIFF
--- a/man/coxph.object.Rd
+++ b/man/coxph.object.Rd
@@ -14,81 +14,81 @@ Objects of this class have methods for the functions \code{print},
 \section{Components}{
 The following components must be included in a legitimate \code{coxph} 
 object. 
-}
-\arguments{
-\item{coefficients}{
+\describe{
+\item{\code{coefficients}}{
   the vector of coefficients.
   If the model is over-determined there will be missing 
   values in the vector corresponding to the redundant columns in the model 
   matrix. 
 }
-\item{var}{
+\item{\code{var}}{
 the variance matrix of the coefficients.  Rows and columns corresponding to 
 any missing coefficients are set to zero. 
 }
-\item{naive.var}{
+\item{\code{naive.var}}{
 this component will be present only if the \code{robust} option was true.  If so, 
 the \code{var} component will contain the robust estimate of variance, and this 
 component will contain the ordinary estimate. (A far better name would
 be \code{asymp.var} since it contains the model-based asympotitic
 variance estimate, which is not necessarily "naive"; but that ship has sailed.)
 }
-\item{loglik}{
+\item{\code{loglik}}{
 a vector of length 2 containing the log-likelihood with the initial values and 
 with the final values of the coefficients. 
 }
-\item{score}{
+\item{\code{score}}{
 value of the efficient score test, at the initial value of the coefficients. 
 }
-\item{rscore}{
+\item{\code{rscore}}{
 the robust log-rank statistic, if a robust variance was requested. 
 }
-\item{wald.test}{
+\item{\code{wald.test}}{
 the Wald test of whether the final coefficients differ from the initial values. 
 }
-\item{iter}{
+\item{\code{iter}}{
 number of iterations used. 
 }
-\item{linear.predictors}{
+\item{\code{linear.predictors}}{
   the vector of linear predictors, one per subject.  Note that this
   vector has been centered, see \code{predict.coxph} for more details.
 }
-\item{residuals}{
+\item{\code{residuals}}{
 the martingale residuals. 
 }
-\item{means}{
+\item{\code{means}}{
   vector of values used as the reference for each covariate.
   For instance, a later call to \code{predict(fit, type='risk')} will
   give the hazard ratio between an observation and this reference.
   (For most covariates this will contain the mean.)
 }
-\item{n}{
+\item{\code{n}}{
 the number of observations used in the fit. 
 }
-\item{nevent}{
+\item{\code{nevent}}{
 the number of events (usually deaths) used in the fit. 
 }
-\item{n.id}{if the call had an \code{id} argument, the number of unique
+\item{\code{n.id}}{if the call had an \code{id} argument, the number of unique
   id values}
-\item{concordance}{a vector of length 6, containing the number of pairs
+\item{\code{concordance}}{a vector of length 6, containing the number of pairs
   that are concordant, discordant, tied on x, tied on y, and tied on both,
   followed by the standard error of the concordance statistic.}
-\item{first}{the first derivative vector at the solution.}
-\item{weights}{
+\item{\code{first}}{the first derivative vector at the solution.}
+\item{\code{weights}}{
 the vector of case weights, if one was used. 
 }
-\item{method}{
+\item{\code{method}}{
 the method used for handling tied survival times.
 }
-\item{na.action}{
+\item{\code{na.action}}{
 the na.action attribute, if any, that was returned by the \code{na.action} 
 routine. 
 }
-\item{timefix}{the value of the timefix option used in the fit}
-\item{...}{
+\item{\code{timefix}}{the value of the timefix option used in the fit}
+\item{\dots}{
 The object will also contain the following, for documentation see the \code{lm} 
 object: \code{terms}, \code{assign}, \code{formula}, \code{call}, and, optionally, \code{x}, \code{y}, 
 and/or \code{frame}. 
+}
 }
 }
 \seealso{

--- a/man/coxphms.object.Rd
+++ b/man/coxphms.object.Rd
@@ -11,27 +11,27 @@ multiple states.  The object inherits from the \code{coxph} class.
 \section{Components}{
   The object has all the components of a \code{coxph} object, with the
   following additions and variations.
-}
-\arguments{
-  \item{states}{a character vector listing the states in the model}
-\item{cmap}{the coefficient map. A matrix containing
+\describe{
+\item{\code{states}}{a character vector listing the states in the model}
+\item{\code{cmap}}{the coefficient map. A matrix containing
   a column for each transition and a row for each coefficient, the value
   maps that transition/coefficient pair to a position in the coefficient
   vector.
   If a particular covariate is not used by a transition the matrix
   will contain a zero in that position, if two transitions share a
   coefficient the matrix will contain repeats.}
-\item{smap}{the stratum map.
+\item{\code{smap}}{the stratum map.
   The row labeled `(Baseline)' identifies transitions that do or do not
   share a baseline hazard.  Further rows correspond to strata() terms
   in the model, each of which may apply to some transitions and not others.
 }
-\item{rmap}{mapping for the residuals and linear predictors.  A two
+\item{\code{rmap}}{mapping for the residuals and linear predictors.  A two
   column matrix with one row for each element of the vectors
   and two columns, the first contains the data row and the second the
   transition.}
 }
-\details{
+}
+\section{Details}{
   In a multi-state model a set of intermediate observations is created
   during the computation, with a separate set of data rows for each
   transition.  An observation (id and time interval) that is at risk for

--- a/man/survexp.object.Rd
+++ b/man/survexp.object.Rd
@@ -13,38 +13,38 @@ methods from \code{survfit}.
 }
 \section{Structure}{
 The following components must be included in a legitimate 
-\code{survfit} 
+\code{survexp} 
 object. 
-}
-\arguments{
-\item{surv}{
+\describe{
+\item{\code{surv}}{
 the estimate of survival at time t+0. 
 This may be a vector or a matrix. 
 }
-\item{n.risk}{
+\item{\code{n.risk}}{
 the number of subjects who contribute at this time.
 }
-\item{time}{
+\item{\code{time}}{
 the time points at which the curve has a step. 
 }
-\item{std.err}{
+\item{\code{std.err}}{
 the standard error of the cumulative hazard or -log(survival). 
 }
-\item{strata}{
+\item{\code{strata}}{
 if there are multiple curves, this component gives the number of elements of 
 the \code{time} etc. vectors corresponding to the first curve,
 the second curve, 
 and so on.  The names of the elements are labels for the curves. 
 }
-\item{method}{the estimation method used.  One of "Ederer", "Hakulinen",
+\item{\code{method}}{the estimation method used.  One of "Ederer", "Hakulinen",
   or "conditional".}
-\item{na.action}{
+\item{\code{na.action}}{
 the returned value from the na.action function, if any.  It will be used 
 in the printout of the curve, e.g., the number of observations deleted due 
 to missing values. 
 }
-\item{call}{
+\item{\code{call}}{
 an image of the call that produced the object. 
+}
 }
 }
 \section{Subscripts}{

--- a/man/survfit.object.Rd
+++ b/man/survfit.object.Rd
@@ -17,113 +17,113 @@ for a print method and is documented on a separate page.
 \section{Structure}{
 The following components must be included in a legitimate 
 \code{survfit} or \code{survfitms} object. 
-}
-\arguments{
-  \item{n}{
+\describe{
+  \item{\code{n}}{
     total number of observations in each curve.
   }
-  \item{time}{
+  \item{\code{time}}{
     the time points at which the curve has a step. 
   }
-  \item{n.risk}{
+  \item{\code{n.risk}}{
     the number of subjects at risk at t. 
   }
-  \item{n.event}{
+  \item{\code{n.event}}{
     the number of events that occur at time t. 
   }
-  \item{n.enter}{
+  \item{\code{n.enter}}{
     for counting process data only, and only if there was an \code{id}
     argument, the number of subjects that enter the risk set during the
     current interval.  If there are event/censoring times at 1, 3, 5 for
     instance, someone who enters at time 1 is counted in the (1, 3]
     interval, i.e., appears in the row for time 3. 
   }
-  \item{n.censor}{
+  \item{\code{n.censor}}{
     for counting process data only,
     the number of subjects who exit the risk set,
     without an event,  at time t. 
     (For right censored data, this number can be computed from the successive
     values of the number at risk).
   }
-  \item{surv}{
+  \item{\code{surv}}{
     the estimate of survival at time t+0. 
     This may be a vector or a matrix. The latter occurs when a set of
     survival curves is created from a single Cox model, in which case
     there is one column for each covariate set. 
   }
-  \item{pstate}{
+  \item{\code{pstate}}{
     a multi-state survival will have the \code{pstate} component
     instead of \code{surv}.
     It will be a matrix containing the estimated probability
     of each state at each time, one column per state.
   }
-  \item{std.err}{
+  \item{\code{std.err}}{
     for a survival curve this contains standard error of the cumulative
     hazard or -log(survival), for a multi-state curve it contains the
     standard error of prev.  This difference is a reflection of
     the fact that each is the natural calculation for that case.
   }
-  \item{cumhaz}{optional.  Contains the cumulative
+  \item{\code{cumhaz}}{optional.  Contains the cumulative
     hazard for each possible transition.
   }
-  \item{counts}{optional. If weights were used, the \code{n.risk} etc
+  \item{\code{counts}}{optional. If weights were used, the \code{n.risk} etc
     elements contain weighted sums; the \code{counts} matrix will
     contain unweighted values.  Weighted values are normally more useful
     for further computation, unweighted may be preferred for labeling or
     printout.
   }
-  \item{strata}{
+  \item{\code{strata}}{
     if there are multiple curves, this component gives the number of
     elements of the \code{time}  vector corresponding to the first curve,
     the second curve, and so on.
     The names of the elements are labels for the curves. 
   }
-  \item{upper}{optional
+  \item{\code{upper}}{optional
     upper (2-sided) confidence limit for the survival curve or probability in state
   }
-  \item{lower}{optional 
+  \item{\code{lower}}{optional 
     lower (2-sidedconfidence limit for the survival curve or probability in state
   }
-  \item{t0}{optional, the starting time for the curve}
-  \item{p0, sp0}{for a multistate object, the distribution of starting
+  \item{\code{t0}}{optional, the starting time for the curve}
+  \item{\code{p0}, \code{sp0}}{for a multistate object, the distribution of starting
     states.  If the curve has a strata dimension, this will be a matrix
     one row per stratum.  The \code{sp0} element has the standard error
     of p0, if p0 was estimated.
   }
-  \item{newdata}{for survival curves from a fitted model, this contains
+  \item{\code{newdata}}{for survival curves from a fitted model, this contains
     the covariate values for the curves
   }
 
-  \item{n.id}{the total number of unique id values that contributed to
+  \item{\code{n.id}}{the total number of unique id values that contributed to
     the curve.  This is only available if the original call used the id
     option.
   }
-  \item{conf.type}{
+  \item{\code{conf.type}}{
     the approximation used to compute the confidence limits. 
   }
-  \item{conf.int}{
+  \item{\code{conf.int}}{
     the level of the confidence limits, e.g. 90 or 95\%. 
   }
-  \item{transitions}{for multi-state data, the total number
+  \item{\code{transitions}}{for multi-state data, the total number
     of transitions of each type.}
-  \item{na.action}{
+  \item{\code{na.action}}{
     the returned value from the na.action function, if any.  It will be used 
     in the printout of the curve, e.g., the number of observations deleted due 
     to missing values. 
   }
-  \item{call}{
+  \item{\code{call}}{
     an image of the call that produced the object. 
   }
-  \item{type}{
+  \item{\code{type}}{
     type of survival censoring. 
   }
-  \item{influence.p, influence.c}{optional influence
+  \item{\code{influence.p}, \code{influence.c}}{optional influence
     matrices for the \code{pstate} (or \code{surv}) and for the
     \code{cumhaz} estimates.
     A list with one element per stratum, each
     element of the list is an array indexed by subject, time, state.
   }
-  \item{version}{the version of the object.  Will be missing, 2, or 3}
+  \item{\code{version}}{the version of the object.  Will be missing, 2, or 3}
+}
 }
 
 \section{Subscripts}{


### PR DESCRIPTION
Looking at the rendered documentation on `coxph.object`, e.g., [the HTML version on CRAN](https://cran.r-project.org/web/packages/survival/refman/survival.html#coxph.object) (but also in PDF and plain-text help):

> ## Arguments
> `coefficients`
>         the vector of coefficients. ...
> ...
> ## Components
> The following components must be included in a legitimate coxph object. 

The first problem is that this uses an `\arguments` section when there are no "arguments": the page documents the structure of an S3 class (comparable to the help on `terms.object`) not a function. The second problem is that the list of components was meant to be included in the Components section after the introductory sentence.

This patch fixes the sectioning for `coxph.object` and similar help pages.