### PR TITLE
Fix name typos in survfit methods

### DIFF
--- a/R/aggregate.survfit.R
+++ b/R/aggregate.survfit.R
@@ -39,7 +39,7 @@ aggregate.survfit <- function(x, by=NULL, FUN= mean, ...) {
     if (is.null(by)) { # simple case
         if (!is.null(x$surv)) {
             if (missing(FUN)) newx$surv <- rowMeans(x$surv)
-            else              news$surv <- apply(x$surv, 1, FUN)
+            else              newx$surv <- apply(x$surv, 1, FUN)
         }
         if (!is.null(x$pstate)) 
             newx$pstate <- apply(x$pstate, c(1,3), FUN)

--- a/R/summary.survfit.R
+++ b/R/summary.survfit.R
@@ -217,7 +217,7 @@ summary.survfit <- function(object, times, censored=FALSE,
             nindx <- rep(1:nrow(fit$newdata), each= nrow(fit$surv))
             if (any(names(fit$newdata) %in% names(ndata))) {
                 # the user's data frame has an already used name, add _
-                names(newdata) <- paste0(names(newdata), "_")
+                names(fit$newdata) <- paste0(names(fit$newdata), "_")
             }             
             ndata <- cbind(ndata, fit$newdata[nindx,])
         } else {

--- a/tests/ry-typos.R
+++ b/tests/ry-typos.R
@@ -1,0 +1,30 @@
+#
+# Regression tests for two name typos in survfit methods
+#
+library(survival)
+aeq <- function(x, y, ...) all.equal(as.vector(x), as.vector(y), ...)
+
+#
+# aggregate.survfit: the FUN= branch assigned to a stray "news" object
+#  instead of "newx", raising an error for any user-supplied FUN.
+#
+cox1 <- coxph(Surv(time, status) ~ ph.ecog + sex, lung)
+nd <- expand.grid(ph.ecog=0:2, sex=1:2)
+sf <- survfit(cox1, newdata=nd)
+
+ag1 <- aggregate(sf)                          # default FUN = mean
+stopifnot(aeq(ag1$surv, rowMeans(sf$surv)))
+
+ag2 <- aggregate(sf, FUN=median)              # explicit FUN
+stopifnot(aeq(ag2$surv, apply(sf$surv, 1, median)))
+
+#
+# summary.survfit: when a newdata column name collides with an internal
+#  column, the rename referenced an undefined "newdata" instead of
+#  "fit$newdata", raising an error.
+#
+nd2 <- data.frame(ph.ecog=0:2, sex=1:2, surv=1:6)   # "surv" collides
+sf2 <- survfit(cox1, newdata=nd2)
+sm2 <- summary(sf2, times=c(100, 200, 300), data.frame=TRUE)
+stopifnot("surv_" %in% names(sm2))            # user column renamed
+stopifnot("surv"  %in% names(sm2))            # internal column retained


### PR DESCRIPTION
Supplying FUN to aggregate.survfit() attempted to write through utils::news, while summary.survfit(..., data.frame = TRUE) referenced an undefined variable when user column names collided with generated output columns.

Found with https://github.com/sims1253/ry