### PR TITLE
Fix column indexing in yates() and survpenal.fit()

### DIFF
--- a/R/survpenal.fit.R
+++ b/R/survpenal.fit.R
@@ -495,8 +495,9 @@ survpenal.fit<- function(x, y, weights, offset, init, controlvals, dist,
 	    df <- dftemp$df
 	    var  <- dftemp$var
 	    var2 <- dftemp$var2
-	    pdf <- df[pterms>0]	          # df's for penalized terms
-	    trH <- dftemp$trH[pterms>0]   # trace H 
+		dfkeep <- which(pterms>0)         # 'assign' has an extra entry for sigma
+        pdf <- df[dfkeep]                 # df's for penalized terms
+        trH <- dftemp$trH[dfkeep]         # trace H 
 	    }
 
 	#
@@ -559,7 +560,7 @@ survpenal.fit<- function(x, y, weights, offset, init, controlvals, dist,
     if (iter.max >1 && length(iterfail)>0)
 	    warning(paste("Inner loop failed to coverge for iterations", 
 			  paste(iterfail, collapse=' ')))
-    which.sing <- (hdiag[nfrail + 1:nvar] ==0)
+	which.sing <- which(hdiag[nfrail + 1:nvar] ==0)
     coef[which.sing] <- NA
 
     names(iterlist) <- names(pterms[pterms>0])

--- a/R/yates.R
+++ b/R/yates.R
@@ -357,7 +357,7 @@ yates <- function(fit, term, population=c("data", "factorial", "sas"),
 
         meanfun <- if (is.null(weight)) colMeans else function(x) {
             colSums(x*weight)/ sum(weight)}
-        Cmat <- t(sapply(xmatlist, meanfun))[,!nabeta]
+        Cmat <- t(sapply(xmatlist, meanfun))
                   
         # coxph model: the X matrix is built as though an intercept were there (the
         #  baseline hazard plays that role), but then drop it from the coefficients
@@ -370,7 +370,8 @@ yates <- function(fit, term, population=c("data", "factorial", "sas"),
             offset <- -sum(fit$means[!nabeta] * beta)  # recenter the predictions too
             }
         else offset <- 0
-            
+        Cmat <- Cmat[,!nabeta, drop=FALSE]
+
         # Get the PMM estimates, but only for estimable ones
         estimate <- cbind(x1data, pmm=NA, std=NA)
         if (any(estimable)) {
@@ -477,12 +478,16 @@ yates <- function(fit, term, population=c("data", "factorial", "sas"),
         if (method=="sgtt") result$SAS <- Smat
     }
     else {
-        xall <- do.call(rbind, xmatlist)[,!nabeta, drop=FALSE]
+        xall <- do.call(rbind, xmatlist)
         if (inherits(fit, "coxph")) {
             xall <- xall[,-1, drop=FALSE]  # remove the intercept
+            xall <- xall[,!nabeta, drop=FALSE]
             eta <- xall %*% beta -sum(fit$means[!nabeta]* beta)
         }
-        else eta <- xall %*% beta
+        else {
+            xall <- xall[,!nabeta, drop=FALSE]
+            eta <- xall %*% beta
+        }
         n1 <- nrow(xmatlist[[1]])  # all of them are the same size
         index <- rep(1:length(xmatlist), each = n1)
         if (is.function(mfun)) predfun <- mfun


### PR DESCRIPTION
Dear Prof Therneau,

During R Dev Day 2026 and RSprint 2026 we prepared some changes to a future version of base R that might affect the `survival` package.

The changes relate to a new warning planned for a future version of R triggered when the length of an object and the length of its logical subscript don't match, e.g.:

```{r}
x <- 1:4
y <- c(10, 20, 30)
x[y > 10]
```

We expect that in a future version of R, this will produce a warning:

```{r}
x[y > 10]
[1] 2 3
Warning message:
In x[y > 10] : object length is not a multiple of subscript length
```

In light of this, we are proposing the attached changes to the `survival` package. All numerical results match, except for one case demonstrated in "R/yates.Rd":

```{r}
fit2 <- coxph(Surv(time, status) ~ factor(ph.ecog)*sex + age, lung)
yates(fit2, ~ ph.ecog, predict="risk")  # hazard ratio
```

Comparing output:

```{r}
> fit2 <- coxph(Surv(time, status) ~ factor(ph.ecog)*sex + age, lung)
> yates(fit2, ~ ph.ecog, predict="risk")
 factor(ph.ecog)     pmm      std                 test chisq df Pr
               0 0.94238  0.50235      factor(ph.ecog)    NA NA NA
               1 1.42677  0.82741                                 
               2 1.74848  4.83611                                 
               3      NA 24.01715
```

Against the "patched" version of `survival`

```{r}
 > yates(fit2, ~ ph.ecog, predict="risk")
 > factor(ph.ecog)     pmm      std                 test chisq df Pr
               0 0.94238  0.40168      factor(ph.ecog)    NA NA NA
               1 1.42677  0.70150                                 
               2 2.31986  1.23147                                 
               3      NA 18.58865
```

The discrepancy comes from how `survival` subsets `xall` in "R/yates.R" (line 480): `xall <- do.call(rbind, xmatlist)[,!nabeta, drop=FALSE]`.

Toy example:

```{r}
library(survival)
fit2 <- coxph(Surv(time, status) ~ factor(ph.ecog)*sex + age, lung)

# factor(ph.ecog)3:sex is aliased -> coef() has an NA in it
beta   <- coef(fit2, complete=TRUE)
nabeta <- is.na(beta)
length(beta) # coxph coef has no intercept

Terms <- terms(fit2)
xall  <- model.matrix(Terms, model.frame(fit2), contrasts.arg=fit2$contrasts)
ncol(xall) # has an intercept col

xall <- xall[, !nabeta, drop=FALSE]  # length-8 logical recycled over 9 cols
xall <- xall[, -1, drop=FALSE]       # then blindly drops col 1
colnames(xall)
```

The output is:

```{r}
> colnames(xall)
[1] "factor(ph.ecog)2"     "factor(ph.ecog)3"     "sex"                 
[4] "age"                  "factor(ph.ecog)1:sex" "factor(ph.ecog)3:sex"
```

In the example above, `factor(ph.ecog)2:sex` is dropped instead of `factor(ph.ecog)3:sex`. This is why the "patched" and current `survival` versions give different results: the patched version drops the intercept column first, and only then subsets by `!nabeta`.

The same subsetting pattern appears again in the `predict="linear"` branch of `yates.R` (used when `predict` is left at its default), and there it is not just a silent wrong answer but a hard failure. Using the same `fit2`:

```{r}
yates(fit2, ~ ph.ecog)
```

Under the current `survival` release this errors out:

```{r}
Error in cmat %*% beta : non-conformable arguments
Calls: yates -> estfun
In addition: Warning message:
In t(sapply(xmatlist, meanfun))[, !nabeta] :
  object length is not a multiple of subscript length
```

The patched version returns a result without error.